### PR TITLE
Set up MySQL and Resque

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org'
 gem 'rails', '~> 5.0.0', '>= 5.0.0.1'
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3'
+gem 'mysql2'
 # Use Puma as the app server
 gem 'puma', '~> 3.0'
 # Use SCSS for stylesheets
@@ -60,3 +61,7 @@ group :development, :test do
   gem 'fcrepo_wrapper'
   gem 'rspec-rails'
 end
+
+gem 'resque', '~> 1.27.1'
+gem 'resque-pool', '~> 0.6.0'
+gem 'resque-scheduler', '~> 4.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -394,9 +394,11 @@ GEM
     mini_magick (4.6.0)
     mini_portile2 (2.1.0)
     minitest (5.10.1)
+    mono_logger (1.1.0)
     multi_json (1.12.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
+    mysql2 (0.4.5)
     nest (2.1.0)
       redic
     nio4r (1.2.1)
@@ -497,6 +499,20 @@ GEM
       uber (~> 0.0.7)
     responders (2.3.0)
       railties (>= 4.2.0, < 5.1)
+    resque (1.27.1)
+      mono_logger (~> 1.0)
+      multi_json (~> 1.0)
+      redis-namespace (~> 1.3)
+      sinatra (>= 0.9.2)
+      vegas (~> 0.1.2)
+    resque-pool (0.6.0)
+      rake
+      resque (~> 1.22)
+    resque-scheduler (4.3.0)
+      mono_logger (~> 1.0)
+      redis (~> 3.3)
+      resque (~> 1.26)
+      rufus-scheduler (~> 3.2)
     retriable (2.1.0)
     rsolr (1.1.2)
       builder (>= 2.1.2)
@@ -524,6 +540,8 @@ GEM
       oauth2
     ruby-progressbar (1.8.1)
     rubyzip (1.2.0)
+    rufus-scheduler (3.3.4)
+      tzinfo
     sass (3.4.23)
     sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
@@ -541,6 +559,8 @@ GEM
     simple_form (3.4.0)
       actionpack (> 4, < 5.1)
       activemodel (> 4, < 5.1)
+    sinatra (1.0)
+      rack (>= 1.0)
     skydrive (1.2.0)
       activesupport
       httmultiparty
@@ -597,6 +617,8 @@ GEM
     uber (0.0.15)
     uglifier (3.0.4)
       execjs (>= 0.3.0, < 3)
+    vegas (0.1.11)
+      rack (>= 1.0.0)
     warden (1.2.6)
       rack (>= 1.0)
     web-console (3.4.0)
@@ -626,8 +648,12 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   listen (~> 3.0.5)
+  mysql2
   puma (~> 3.0)
   rails (~> 5.0.0, >= 5.0.0.1)
+  resque (~> 1.27.1)
+  resque-pool (~> 0.6.0)
+  resque-scheduler (~> 4.3.0)
   rsolr (~> 1.0)
   rspec-rails
   sass-rails (~> 5.0)
@@ -641,4 +667,4 @@ DEPENDENCIES
   web-console
 
 BUNDLED WITH
-   1.11.2
+   1.14.2

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,8 +8,10 @@ Bundler.require(*Rails.groups)
 
 module DeepBlue
   class Application < Rails::Application
-    
-     config.active_job.queue_adapter = :inline
+
+    # Use Resque when in production mode, inline otherwise.
+    # config.active_job.queue_adapter = :resque
+    config.active_job.queue_adapter = :inline
 
       # The compile method (default in tinymce-rails 4.5.2) doesn't work when also
       # using tinymce-rails-imageupload, so revert to the :copy method

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,8 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  config.active_job.queue_adapter = :resque
+
   # Code is not reloaded between requests.
   config.cache_classes = true
 


### PR DESCRIPTION
This adds dependencies for MySQL and Resque. It configures the production environment to use Resque, but inline ActiveJob otherwise. Likewise, only the mysql2 driver is added here; `database.yml` is not changed.