### PR TITLE
Fix QA migration

### DIFF
--- a/db/migrate/20170201210418_create_qa_local_authority_entries.rb
+++ b/db/migrate/20170201210418_create_qa_local_authority_entries.rb
@@ -1,7 +1,7 @@
 class CreateQaLocalAuthorityEntries < ActiveRecord::Migration[5.0]
   def change
     create_table :qa_local_authority_entries do |t|
-      t.references :local_authority, foreign_key: true
+      t.references :qa_local_authority, foreign_key: true
       t.string :label
       t.string :uri
 


### PR DESCRIPTION
There is a bug in Hyrax right now where one of the QA migrations generated references the wrong table. It just needs the `qa` prefix.