### PR TITLE
Fix namespace issues in WorkShowPresenter

### DIFF
--- a/app/presenters/deepblue/work_show_presenter.rb
+++ b/app/presenters/deepblue/work_show_presenter.rb
@@ -1,7 +1,7 @@
 module Deepblue
   class WorkShowPresenter
-    include ModelProxy
-    include PresentsAttributes
+    include Hyrax::ModelProxy
+    include Hyrax::PresentsAttributes
     attr_accessor :solr_document, :current_ability, :request
 
     # delegate fields from Hyrax::Works::Metadata to solr_document


### PR DESCRIPTION
Because the WorkShowPresenter is not in the Hyrax namespace, the ModelProxy and PresentsAttributes must be qualified.

This was stopping the puma workers from starting because it eagerly loads everything under the app directory in production mode. This doesn't happen in development mode, so things appear to start normally there.