### PR TITLE
add disseration type work (not yet customized)

### DIFF
--- a/app/actors/hyrax/actors/dissertation_actor.rb
+++ b/app/actors/hyrax/actors/dissertation_actor.rb
@@ -1,0 +1,8 @@
+# Generated via
+#  `rails generate hyrax:work Dissertation`
+module Hyrax
+  module Actors
+    class DissertationActor < Hyrax::Actors::BaseActor
+    end
+  end
+end

--- a/app/controllers/hyrax/dissertations_controller.rb
+++ b/app/controllers/hyrax/dissertations_controller.rb
@@ -1,0 +1,11 @@
+# Generated via
+#  `rails generate hyrax:work Dissertation`
+
+module Hyrax
+  class DissertationsController < ApplicationController
+    # Adds Hyrax behaviors to the controller.
+    include Hyrax::WorksControllerBehavior
+    include Hyrax::BreadcrumbsForWorks
+    self.curation_concern_type = Dissertation
+  end
+end

--- a/app/forms/hyrax/dissertation_form.rb
+++ b/app/forms/hyrax/dissertation_form.rb
@@ -1,0 +1,8 @@
+# Generated via
+#  `rails generate hyrax:work Dissertation`
+module Hyrax
+  class DissertationForm < Hyrax::Forms::WorkForm
+    self.model_class = ::Dissertation
+    self.terms += [:resource_type]
+  end
+end

--- a/app/models/dissertation.rb
+++ b/app/models/dissertation.rb
@@ -1,0 +1,11 @@
+# Generated via
+#  `rails generate hyrax:work Dissertation`
+class Dissertation < ActiveFedora::Base
+  include ::Hyrax::WorkBehavior
+  include ::Hyrax::BasicMetadata
+  # Change this to restrict which works can be added as a child.
+  # self.valid_child_concerns = []
+  validates :title, presence: { message: 'Your work must have a title.' }
+  
+  self.human_readable_type = 'Dissertation'
+end

--- a/app/views/hyrax/dissertations/_dissertation.html.erb
+++ b/app/views/hyrax/dissertations/_dissertation.html.erb
@@ -1,0 +1,2 @@
+<%# This is a search result view %>
+<%= render 'catalog/document', document: dissertation, document_counter: dissertation_counter  %>

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -1,6 +1,8 @@
 Hyrax.config do |config|
   # Injected via `rails g hyrax:work Work`
   config.register_curation_concern :work
+  # Injected via `rails g hyrax:work Dissertation`
+  config.register_curation_concern :dissertation
   # Email recipient of messages sent via the contact form
   # config.contact_email = "repo-admin@example.org"
 

--- a/config/locales/dissertation.en.yml
+++ b/config/locales/dissertation.en.yml
@@ -1,0 +1,8 @@
+en:
+  hyrax:
+    icons:
+      dissertation:     'fa fa-file-text-o'
+    select_type:
+      dissertation:
+        name:               "Dissertation"
+        description:        "Dissertation works"

--- a/config/locales/dissertation.es.yml
+++ b/config/locales/dissertation.es.yml
@@ -1,0 +1,10 @@
+es:
+  hyrax:
+    icons:
+      dissertation:     'fa fa-file-text-o'
+    select_type:
+      dissertation:
+        # TODO: translate `human_name` into Spanish
+        name:               "Dissertation"
+        # TODO: translate `human_name` into Spanish
+        description:        "Dissertation trabajos"

--- a/spec/actors/hyrax/actors/dissertation_actor_spec.rb
+++ b/spec/actors/hyrax/actors/dissertation_actor_spec.rb
@@ -1,0 +1,9 @@
+# Generated via
+#  `rails generate hyrax:work Dissertation`
+require 'rails_helper'
+
+RSpec.describe Hyrax::Actors::DissertationActor do
+  it "has tests" do
+    skip "Add your tests here"
+  end
+end

--- a/spec/controllers/hyrax/dissertations_controller_spec.rb
+++ b/spec/controllers/hyrax/dissertations_controller_spec.rb
@@ -1,0 +1,9 @@
+# Generated via
+#  `rails generate hyrax:work Dissertation`
+require 'rails_helper'
+
+RSpec.describe Hyrax::DissertationsController do
+  it "has tests" do
+    skip "Add your tests here"
+  end
+end

--- a/spec/features/create_dissertation_spec.rb
+++ b/spec/features/create_dissertation_spec.rb
@@ -1,0 +1,26 @@
+# Generated via
+#  `rails generate hyrax:work Dissertation`
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.feature 'Create a Dissertation' do
+  context 'a logged in user' do
+    let(:user_attributes) do
+      { email: 'test@example.com' }
+    end
+    let(:user) do
+      User.new(user_attributes) { |u| u.save(validate: false) }
+    end
+
+    before do
+      login_as user
+    end
+
+    scenario do
+      visit new_curation_concerns_dissertation_path
+      fill_in 'Title', with: 'Test Dissertation'
+      click_button 'Create Dissertation'
+      expect(page).to have_content 'Test Dissertation'
+    end
+  end
+end

--- a/spec/forms/hyrax/dissertation_form_spec.rb
+++ b/spec/forms/hyrax/dissertation_form_spec.rb
@@ -1,0 +1,9 @@
+# Generated via
+#  `rails generate hyrax:work Dissertation`
+require 'rails_helper'
+
+RSpec.describe Hyrax::DissertationForm do
+  it "has tests" do
+    skip "Add your tests here"
+  end
+end

--- a/spec/models/dissertation_spec.rb
+++ b/spec/models/dissertation_spec.rb
@@ -1,0 +1,9 @@
+# Generated via
+#  `rails generate hyrax:work Dissertation`
+require 'rails_helper'
+
+RSpec.describe Dissertation do
+  it "has tests" do
+    skip "Add your tests here"
+  end
+end


### PR DESCRIPTION
Add a new work type call "Dissertation"
Additional work will be needed to customize this type in terms of the required and optional metadata

Note the change to _config/initializers/hyrax.rb_ this is what triggers an additional work type to display when you are creating a work. You don't have to add this; it is automatically created when you stop the server (control-c) and restart it.